### PR TITLE
chore(security): lodash/lodash-esのminimumReleaseAge除外を解除

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,12 +5,6 @@ minimumReleaseAge: 10080 # 1 week
 overrides:
   brace-expansion@<1.1.13: '>=1.1.13'
   tmp@<=0.2.3: '>=0.2.4'
-  lodash@<=4.17.23: ">=4.18.1"
-  lodash-es@<=4.17.23: ">=4.18.1"
-# lodash 4.18.x がminimumReleaseAge (7日) を超えたら削除すること
-minimumReleaseAgeExclude:
-  - lodash
-  - lodash-es
 packageManagerStrictVersion: true
 savePrefix: ""
 trustPolicy: no-downgrade


### PR DESCRIPTION
## 概要

`chore/migrate-to-pnpm-security-settings` ブランチで追加した以下の一時的な設定を削除します。

## 変更内容

- `minimumReleaseAgeExclude` から `lodash` / `lodash-es` を削除
- `overrides` から `lodash@<=4.17.23` / `lodash-es@<=4.17.23` の強制更新を削除

## 背景

lodash 4.18.x は GHSA-r5fr-rjxr-66jc (Code Injection) を修正したバージョンですが、
公開から7日未満のため `minimumReleaseAge` に引っかかっていました。

- lodash 4.18.0: 公開 2026-03-31 → 利用可能 2026-04-07
- lodash 4.18.1: 公開 2026-04-01 → 利用可能 2026-04-08

## マージ条件

- `chore/migrate-to-pnpm-security-settings` PRがマージされた後にマージしてください
- **2026-04-08以降** にマージ可能（lodash 4.18.x が minimumReleaseAge を超えるため）