### PR TITLE
ci(publish): GCP Artifact Registry への publish を導入する

### DIFF
--- a/.github/workflows/publish-to-artifactregistry.yml
+++ b/.github/workflows/publish-to-artifactregistry.yml
@@ -21,8 +21,8 @@ jobs:
         name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
-          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}
+          workload_identity_provider: projects/451915692272/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider
+          service_account: gha-artifactregistry@intimatemerger.iam.gserviceaccount.com
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1

--- a/.github/workflows/publish-to-artifactregistry.yml
+++ b/.github/workflows/publish-to-artifactregistry.yml
@@ -1,0 +1,43 @@
+name: Publish to ArtifactRegistry
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
+      - name: Use Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 22.x
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Login to ArtifactRegistry
+        run: npm run artifactregistry-login
+
+      - name: Publish to ArtifactRegistry
+        run: npm publish

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# Artifact Registry (asia-northeast1) — @intimatemerger-internal scope のみ AR を使う
+@intimatemerger-internal:registry=https://asia-northeast1-npm.pkg.dev/intimatemerger/npm-intimatemerger-internal/
+//asia-northeast1-npm.pkg.dev/intimatemerger/npm-intimatemerger-internal/:always-auth=true

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@intimatemerger/im-core",
+  "name": "@intimatemerger-internal/im-core",
   "version": "0.2.3",
   "license": "MIT",
   "main": "./cjs/index.js",
@@ -21,7 +21,8 @@
     "test-server": "node ./test-server/start.js",
     "test": "npm run test:vitest",
     "test:vitest": "vitest run",
-    "test:vitest:watch": "vitest"
+    "test:vitest:watch": "vitest",
+    "artifactregistry-login": "npx google-artifactregistry-auth"
   },
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
## Summary

npm registry への手動 publish 運用から、IMUID-js と同じ
asia-northeast1 の Artifact Registry (intimatemerger プロジェクト
配下の \`npm-intimatemerger-internal\` repo) への自動 publish に
切り替えるのだ。

リファレンス:
[IntimateMerger/IMUID-js/.github/workflows/publish-to-artifactregistry.yml](https://github.com/IntimateMerger/IMUID-js/blob/master/.github/workflows/publish-to-artifactregistry.yml)

migration PR (#10) とは独立した PR として進めるのだ。
マージ順序は問わないが、AR publish が動くのは pnpm 移行とは無関係なので
こちらだけ先にマージしても問題ないのだ。

## Changes

- **`.npmrc`** を新規追加 (scope mapping):
  \`\`\`
  @intimatemerger-internal:registry=https://asia-northeast1-npm.pkg.dev/intimatemerger/npm-intimatemerger-internal/
  //asia-northeast1-npm.pkg.dev/intimatemerger/npm-intimatemerger-internal/:always-auth=true
  \`\`\`
- **\`package.json\`**:
  - \`name\` を \`@intimatemerger/im-core\` → \`@intimatemerger-internal/im-core\` にリネーム
  - \`artifactregistry-login\` script を追加 (\`npx google-artifactregistry-auth\`)
- **\`.github/workflows/publish-to-artifactregistry.yml\`** を新規追加:
  - master push と workflow_dispatch がトリガ
  - WIF 経由で SA を impersonate (\`vars.WORKLOAD_IDENTITY_PROVIDER\` /
    \`vars.WORKLOAD_IDENTITY_SERVICE_ACCOUNT\`)
  - \`npm ci\` → \`npm run build\` → \`npm run artifactregistry-login\` → \`npm publish\`
  - action SHA は IM ポリシーに合わせて pinact 済み (auth v3.0.0 /
    setup-gcloud v3.0.1 / checkout v6.0.2 / setup-node v6.3.0)

## マージ前に必要な GCP / GitHub 設定

リポジトリ admin / GCP admin が以下を実施する必要があるのだ:

### GCP 側

1. SA 作成 (\`gcloud iam service-accounts create im-core-github-actions\`)
2. SA に \`roles/artifactregistry.writer\` 付与 (AR repo の IAM)
3. SA に shared WIF Pool から \`roles/iam.workloadIdentityUser\` 付与
   (principalSet で \`IntimateMerger/im-core\` repo 全体に対して)

### GitHub 側

\`Settings > Variables > Actions\` で:

- \`WORKLOAD_IDENTITY_PROVIDER\`: \`projects/451915692272/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider\`
- \`WORKLOAD_IDENTITY_SERVICE_ACCOUNT\`: \`im-core-github-actions@intimatemerger.iam.gserviceaccount.com\`

詳細手順は監査リポの
[AR_PUBLISH_SETUP.md](https://github.com/intimatemerger-npm-audit/AR_PUBLISH_SETUP.md) (社内 doc) を参照するのだ。

## Test plan

- [ ] 設定完了後、master へマージして \`Publish to ArtifactRegistry\` workflow が走ることを確認
- [ ] AR コンソールで \`@intimatemerger-internal/im-core@0.2.3\` が登録されることを確認
- [ ] 下流リポ (trust360 等) の依存切り替えは別 PR で対応

Co-Authored-By: Claude <noreply@anthropic.com>