### PR TITLE
ci(workflow): prune action 参照を IntimateMerger@v1.0.2 へ統一

### DIFF
--- a/.github/workflows/prune-supply-chain.yml
+++ b/.github/workflows/prune-supply-chain.yml
@@ -25,6 +25,6 @@ jobs:
         with:
           node-version-file: package.json
 
-      - uses: april418/prune-supply-chain-overrides-action@4429d172862c6ec658f0ddb69b1ee31e1d8a8f25 # v1.0.1
+      - uses: IntimateMerger/prune-supply-chain-overrides-action@0e16deedcabd3995212707a1afe2dcc484f26c38 # v1.0.2
         with:
           working-directory: .


### PR DESCRIPTION
## Summary

既存の prune-supply-chain workflow の action 参照を、個人アカウント/`@master` 固定から org 配下のリリース版 `IntimateMerger/prune-supply-chain-overrides-action@v1.0.2`（full SHA pin）へ統一します。

## Changes

- `.github/workflows/prune-supply-chain.yml` の action 参照を v1.0.2 へ更新

## Test plan

- [ ] Actions タブで workflow が有効に認識されること

Co-Authored-By: Claude <noreply@anthropic.com>