### PR TITLE
fix: types フィールドの拡張子を .d.ts へ修正する (0.3.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@intimatemerger-internal/im-core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "main": "./cjs/index.js",
-  "types": "./cjs/index.d.js",
+  "types": "./cjs/index.d.ts",
   "files": [
     "cjs",
     "esm"


### PR DESCRIPTION
## 概要

`package.json` の `types` フィールドが存在しない拡張子 `./cjs/index.d.js`（`.d.js`）を指していた typo を、実在する `./cjs/index.d.ts` に修正する。**0.3.1** として publish する。

## 影響

`types` が解決できないため、**bare import の型が `any` にフォールバック**していた。

```ts
// 影響あり（bare import）— im-cmp/src/lib/Storage.ts で使用
import { Cookie } from '@intimatemerger-internal/im-core';

// 影響なし（subpath import）— 各自の .d.ts を直接解決
import { XHR } from '@intimatemerger-internal/im-core/esm/XHR';
```

vitest / esbuild ビルドは型チェックしないため実行時の不具合は無く、潜在的な型欠落バグだった。

## 修正内容

- `types`: `./cjs/index.d.js` → `./cjs/index.d.ts`
- `version`: 0.3.0 → 0.3.1

## 検証

- `pnpm build` ✅（`cjs/index.d.ts` 生成・`Cookie`/`XHR`/`LocalStorage`/`SessionStorage`/`sendBeacon` を export）
- `pnpm lint` ✅ / `pnpm test` 51 passed ✅
- `types` 先 `cjs/index.d.ts` の実在を確認 ✅

## マージ後

master マージで CI が 0.3.1 を ArtifactRegistry へ publish する。bare import を使う **im-cmp** は 0.3.1 へ更新すると型が正しく付く（任意・別 PR）。subpath import のみの consumer は更新不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)