### PR TITLE
feat: exports マップ導入 + ESM 優先構成に刷新する (0.4.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,14 @@
   "types": "./esm/index.d.ts",
   "exports": {
     ".": {
-      "types": "./esm/index.d.ts",
-      "import": "./esm/index.js",
-      "require": "./cjs/index.js"
+      "import": {
+        "types": "./esm/index.d.ts",
+        "default": "./esm/index.js"
+      },
+      "require": {
+        "types": "./cjs/index.d.ts",
+        "default": "./cjs/index.js"
+      }
     },
     "./esm": {
       "types": "./esm/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,34 @@
 {
   "name": "@intimatemerger-internal/im-core",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "license": "MIT",
   "main": "./cjs/index.js",
-  "types": "./cjs/index.d.ts",
+  "module": "./esm/index.js",
+  "types": "./esm/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./esm/index.d.ts",
+      "import": "./esm/index.js",
+      "require": "./cjs/index.js"
+    },
+    "./esm": {
+      "types": "./esm/index.d.ts",
+      "default": "./esm/index.js"
+    },
+    "./esm/*": {
+      "types": "./esm/*.d.ts",
+      "default": "./esm/*.js"
+    },
+    "./cjs": {
+      "types": "./cjs/index.d.ts",
+      "default": "./cjs/index.js"
+    },
+    "./cjs/*": {
+      "types": "./cjs/*.d.ts",
+      "default": "./cjs/*.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "cjs",
     "esm"


### PR DESCRIPTION
## 概要

`im-core` のパッケージ構成を **`exports` マップ + ESM 優先**に刷新する。**0.4.0** として publish する。#17 (types typo 修正・0.3.1) の続きで、`main`/`types` が cjs 固定だった構成を現代化する。

## 変更内容

- `exports` フィールドを導入し条件付き解決を定義
  - `.` → `import: esm` / `require: cjs` / `types: esm`
  - `./esm`, `./esm/*` → esm（既存 consumer が使用）
  - `./cjs`, `./cjs/*` → cjs（require 系フォールバック）
  - `./package.json`
- `module` フィールド追加（bundler 向け esm ヒント）
- `types` を `./esm/index.d.ts` に
- `version`: 0.3.1 → 0.4.0

既存 consumer の import パターン（bare `.` / `./esm` バレル / `./esm/XHR` 等）を**全て維持**する非破壊設計。

## 検証

im-core を参照する全 consumer の node_modules を本ブランチの im-core で差し替え、build/compile が通ることを確認：

| consumer | ツール | import | 結果 |
|---|---|---|---|
| im-cmp | webpack | bare `.` (named) | ✅ |
| im-query-param-injector-js | tsc | imuid 経由 `/esm/*` 型 | ✅ |
| trust360 | webpack | `/esm` バレル | ✅ |
| livedoor-cdp-client | rolldown | `/esm` バレル | ✅ |
| beacon.js | webpack | `/esm/*` | ✅ |
| gpt-secure-signal-provider-js | esbuild | `/esm/*` | ✅ |
| im-uid-clients-livedoor | build | `/esm/*` | ✅ |

im-core 自身: `pnpm build` ✅ / `pnpm lint` ✅ / `pnpm test` 51 passed ✅

## 既知の制約

`esm/*.js` は TS 出力が**拡張子なし相対 import** のため Node ネイティブ ESM では読めず **bundler 専用**。`type:"module"` を付けると逆に Node ESM が `ERR_MODULE_NOT_FOUND` で壊れるため付与しない。真の Node-ESM 対応は `.js` 拡張子を出力するビルド改修が別途必要（フォローアップ）。

## マージ後

CI が 0.4.0 を publish。bare import で型の恩恵を受ける **im-cmp** を 0.4.0 へ更新（別 PR）。subpath のみの consumer は更新不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)