### PR TITLE
chore: version を 0.4.1 へ (failed publish 復旧)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@intimatemerger-internal/im-core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "main": "./cjs/index.js",
   "module": "./esm/index.js",


### PR DESCRIPTION
#19(gitignore) マージ後の publish-to-AR が version 0.4.0 衝突で失敗していた（publish workflow は master push 毎に pnpm publish する設計）。0.4.1 へ上げて publish を通す。

- published 物の内容は 0.4.0 と同一（cjs/esm 非コミット化は publish 内容に無影響、CI が再ビルド）
- 関連: im-ulid も同様に 0.1.1 へ (#8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)