### PR TITLE
ci(prune): prune workflow に AR 認証を追加

### DIFF
--- a/.github/workflows/prune-supply-chain.yml
+++ b/.github/workflows/prune-supply-chain.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   prune:
@@ -24,6 +25,19 @@ jobs:
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: package.json
+
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+
+      - name: Login to ArtifactRegistry
+        run: npx --yes google-artifactregistry-auth
 
       - uses: IntimateMerger/prune-supply-chain-overrides-action@3eee6bcd79a4067a84c9a0902c898add08cabb1f # v1.0.4
         with:


### PR DESCRIPTION
## 概要
prune-supply-chain workflow に AR 認証を追加する。

## 背景
prune action は override の要否を `pnpm install` で検証するが、`@intimatemerger-internal/*` を AR から取得する際 **401 Unauthorized**（No authorization header）になり、判定できず常に全 override を keep していた（prune が実質機能していない）。

## 変更
- `permissions: id-token: write` 追加
- WIF 認証 + setup-gcloud + `npx google-artifactregistry-auth` を prune action の前に追加（test/upload workflow と同じパターン）

🤖 Generated with [Claude Code](https://claude.com/claude-code)