### PR TITLE
ci(workflow): prune action を v1.0.4 に再 pin する

### DIFF
--- a/.github/workflows/prune-supply-chain.yml
+++ b/.github/workflows/prune-supply-chain.yml
@@ -25,6 +25,6 @@ jobs:
         with:
           node-version-file: package.json
 
-      - uses: IntimateMerger/prune-supply-chain-overrides-action@0e16deedcabd3995212707a1afe2dcc484f26c38 # v1.0.2
+      - uses: IntimateMerger/prune-supply-chain-overrides-action@3eee6bcd79a4067a84c9a0902c898add08cabb1f # v1.0.4
         with:
           working-directory: .


### PR DESCRIPTION
## Summary

prune-supply-chain-overrides-action の pin を v1.0.2 (`0e16dee`) から v1.0.4 (`3eee6bc`) へ更新する。

v1.0.2 には 2 つのバグがあった:

1. **default branch 検出**: `git symbolic-ref refs/remotes/origin/HEAD` のみで判定していたが `actions/checkout` は `origin/HEAD` を設定しないため常に `"main"` にフォールバック。default が `main` 以外（`master`/`develop`）の repo では `pulls.create` が `base invalid` で失敗し prune PR を作れなかった。
2. **override over-pruning**: 必要性判定で `resolvedVersions` をセレクタ込みキー（`tmp@<0.2.6`）で引いて常に undefined となり、`name@selector` 形式の override を一律削除。まだ load-bearing なセキュリティ override まで消し、脆弱版を再混入する PR を生成していた。

v1.0.3 で①、v1.0.4 で②を修正済み。実機検証も完了している。

## Changes

- `.github/workflows/prune-supply-chain.yml` の `uses:` を `@3eee6bc... # v1.0.4` へ再 pin

## Test plan

- [ ] マージ後、`Prune supply-chain overrides` を `workflow_dispatch` で手動実行し、prune PR が正しく作成され、load-bearing な override が保持されることを確認

Co-Authored-By: Claude <noreply@anthropic.com>